### PR TITLE
Removed closing of remote process handles

### DIFF
--- a/check_alertable.cpp
+++ b/check_alertable.cpp
@@ -49,7 +49,6 @@ HANDLE find_alertable_by_event(HANDLE hProcess, std::vector<DWORD>& threads)
     // 6. Close source + target handles
     for (i = 0; i < cnt; i++) {
         CloseHandle(eventHandlesL[i]);
-        CloseHandle(eventHandlesR[i]);
         if (threadHandles[i] != signaledThread) {
             CloseHandle(threadHandles[i]);
         }


### PR DESCRIPTION
When I first tried reimplementing *modexp* code to identify alertable threads and afterwards attempted to use your implementation, I discovered an exception being thrown.
  
*eventHandlesR* is a duplicate of *eventHandlesL*, which is located in the targeted remote process. *CloseHandle()* can not be used on remote processes , since from this scope they are invalid - which causes an exception. Removing the cleaning `CloseHandle(eventHandlesR[i]);` is resolving this issue.
Thank you for the great work, I hope this pull helps.